### PR TITLE
caskroom/versions tap

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -5,6 +5,11 @@ execute "tap phinze/homebrew-cask" do
   not_if "brew tap | grep 'cask' > /dev/null 2>&1"
 end
 
+execute "tap caskroom/versions" do
+  command "brew tap caskroom/versions"
+  not_if "brew tap | grep 'cask' > /dev/null 2>&1"
+end
+
 package "brew-cask"
 
 directory '/opt/homebrew-cask/Caskroom' do

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -7,7 +7,7 @@ end
 
 execute "tap caskroom/versions" do
   command "brew tap caskroom/versions"
-  not_if "brew tap | grep 'cask' > /dev/null 2>&1"
+  not_if "brew tap | grep 'versions' > /dev/null 2>&1"
 end
 
 package "brew-cask"


### PR DESCRIPTION
Added the tap so that alternative versions of apps could be installed. Required to enable sublime_text3 in sprout without hacks.