### PR TITLE
upgrade returns non-zero if already on latest version

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -9,6 +9,7 @@ package 'brew-cask'
 
 package 'brew-cask' do
   action :upgrade
+  ignore_failure true
 end
 
 directory '/opt/homebrew-cask/Caskroom' do


### PR DESCRIPTION
I'm not sure this is really the proper fix, but it _does_ prevent a chef run from completely failing.

This is roughly the same functionality that [existed before](https://github.com/pivotal-sprout/sprout-homebrew/commit/f71a372434d39114f04fb890069555f08d3530cd#diff-b3039281f18eb7df068fe2e6e099831c)

See [this issue](https://github.com/pivotal-sprout/sprout-homebrew/issues/5) for details.

Also note that [homebrew purposefully exits with non-zero in this case](https://github.com/Homebrew/homebrew/issues/27048)
