### PR TITLE
Be specific

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -10,9 +10,9 @@ execute 'tap cask' do
   user node['sprout']['user']
 end
 
-package 'brew-cask'
+package 'caskroom/cask/brew-cask'
 
-package 'brew-cask' do
+package 'caskroom/cask/brew-cask' do
   action :upgrade
   ignore_failure true
 end


### PR DESCRIPTION
There is more than 1 brew-cask, the command fails if we're not specific.