### PR TITLE
brew update in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm: system
 install:
   - sudo gem install bundler --no-ri --no-rdoc
   - sudo ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future bundle install
+  - brew update
 script:
   - bundle exec rake ci

--- a/soloistrc
+++ b/soloistrc
@@ -2,8 +2,6 @@ recipes:
   - sprout-homebrew
 
 node_attributes:
-  homebrew:
-    auto-update: true
   sprout:
     homebrew:
       casks:


### PR DESCRIPTION
This was recently introduced into the soloistrc, but only to convince
Travis to use the latest revision of homebrew. Other cookbooks have
since used the pattern of running `brew update` as part of the Travis
install step, so this should do the same.