### PR TITLE
Update README to point to current cask repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/pivotal-sprout/sprout-homebrew.png?branch=master)](https://travis-ci.org/pivotal-sprout/sprout-homebrew)
 
-A Chef cookbook to install Homebrew [formulae](https://github.com/mxcl/homebrew/tree/master/Library/Formula) for packages and [casks](https://github.com/phinze/homebrew-cask/blob/master/USAGE.md) for applications.
+A Chef cookbook to install Homebrew [formulae](https://github.com/mxcl/homebrew/tree/master/Library/Formula) for packages and [casks](https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md) for applications.
 
 ## Usage
 


### PR DESCRIPTION
phinze/homebrew-cask is deprecated in favor of caskroom/homebrew-cask