### PR TITLE
Fix tap cask recipe

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -5,11 +5,7 @@ directory '/usr/local/Library/Taps' do
   recursive true
 end
 
-execute 'tap cask' do
-  command 'brew tap "caskroom/cask"'
-  not_if '/usr/local/bin/brew tap | grep caskroom/cask'
-  user node['sprout']['user']
-end
+homebrew_tap 'caskroom/cask'
 
 package 'caskroom/cask/brew-cask'
 

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -6,7 +6,8 @@ directory '/usr/local/Library/Taps' do
 end
 
 execute 'tap cask' do
-  command 'brew tap "caskroom/homebrew-cask"'
+  command 'brew tap "caskroom/cask"'
+  not_if '/usr/local/bin/brew tap | grep caskroom/cask'
   user node['sprout']['user']
 end
 


### PR DESCRIPTION
Brew has recently changed the output of tap from `name-of-tap/homebrew-tap` to `name-of-tap/tap`. 