### PR TITLE
Remove cask install

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -5,15 +5,6 @@ directory '/usr/local/Library/Taps' do
   recursive true
 end
 
-homebrew_tap 'caskroom/cask'
-
-package 'caskroom/cask/brew-cask'
-
-package 'caskroom/cask/brew-cask' do
-  action :upgrade
-  ignore_failure true
-end
-
 directory '/opt/homebrew-cask/Caskroom' do
   action :create
   recursive true

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -16,3 +16,8 @@ end
 directory '/opt/homebrew-cask' do
   owner node['sprout']['user']
 end
+
+directory '/Library/Caches/Homebrew/Casks' do
+  owner node['sprout']['user']
+  group 'staff'
+end


### PR DESCRIPTION
Homebrew-cask has been [moved into homebrew proper](https://github.com/caskroom/homebrew-cask/blob/master/README.md). This PR removes the installation of the legacy `caskroom/cask/brew-cask` package.

It also configures `/Library/Caches/Homebrew/Casks` to have owner `node['sprout']['user']` since cask installations will fail to copy cached packages into this directory if left with owner as `root`.
